### PR TITLE
RDSに接続するだけのLambda関数を作成

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 build:
 	GOOS=linux GOARCH=amd64 go build -o bin/generatelgtmimage ./cmd/lambda/generatelgtmimage/main.go
+	GOOS=linux GOARCH=amd64 go build -o bin/storelgtmimage ./cmd/lambda/storelgtmimage/main.go
 
 clean:
 	rm -rf ./bin

--- a/README.md
+++ b/README.md
@@ -18,11 +18,19 @@ AWS Lambda + Goで実装しています。
 [direnv](https://github.com/direnv/direnv) 等を利用して環境変数を設定します。
 
 ```
-export DEPLOY_STAGE=デプロイステージを設定、デフォルトは dev
+export DEPLOY_STAGE=デプロイステージを設定
 export REGION=AWSのリージョンを指定、例えば ap-northeast-1 等
-export TRIGGER_BUCKET_NAME=Lambda関数実行のトリガーとなるS3バケット名を指定
+export GENERATE_TRIGGER_BUCKET_NAME=generateLgtmImage Lambda関数実行のトリガーとなるS3バケット名を指定
+export STORE_TRIGGER_BUCKET_NAME=storeLgtmImage Lambda関数実行のトリガーとなるS3バケット名を指定
 export DESTINATION_BUCKET_NAME=LGTM画像がアップロードされるS3バケット名を指定
 export AWS_PROFILE=AWSのProfileを指定
+export DB_HOSTNAME=DBのホスト名を指定
+export DB_USERNAME=DBのユーザー名を指定
+export DB_PASSWORD=DBのパスワードを指定
+export DB_NAME=DBのデータベース名を指定
+export SUBNET_ID_1=サブネットIDを指定
+export SUBNET_ID_2=サブネットIDを指定
+export SECURITY_GROUP_ID=Lambdaのセキュリティグループを指定
 ```
 
 ### デプロイ

--- a/cmd/lambda/storelgtmimage/main.go
+++ b/cmd/lambda/storelgtmimage/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+type User struct {
+	id   int
+	name string
+}
+
+func Handler() {
+	host := os.Getenv("DB_READER_HOSTNAME")
+	password := os.Getenv("DB_PASSWORD")
+	user := os.Getenv("DB_USERNAME")
+	dbName := os.Getenv("DB_NAME")
+
+	dataSourceName := user + ":" + password + "@tcp(" + host + ")/" + dbName
+	db, err := sql.Open("mysql", dataSourceName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`select id, name from user`)
+
+	var userResult []User
+	for rows.Next() {
+		user := User{}
+		if err := rows.Scan(&user.id, &user.name); err != nil {
+			log.Fatal(err)
+		}
+		userResult = append(userResult, user)
+	}
+
+	for _, u := range userResult {
+		fmt.Println(u)
+	}
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/cmd/lambda/storelgtmimage/main.go
+++ b/cmd/lambda/storelgtmimage/main.go
@@ -16,7 +16,7 @@ type User struct {
 }
 
 func Handler() {
-	host := os.Getenv("DB_READER_HOSTNAME")
+	host := os.Getenv("DB_HOSTNAME")
 	password := os.Getenv("DB_PASSWORD")
 	user := os.Getenv("DB_USERNAME")
 	dbName := os.Getenv("DB_NAME")

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/disintegration/imaging v1.6.2
 	github.com/fnproject/fdk-go v0.0.6
 	github.com/fogleman/gg v1.3.0
+	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/tencentyun/scf-go-lib v0.0.0-20200624065115-ba679e2ec9c9
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/fnproject/fdk-go v0.0.6 h1:Q+o8GC2TqJ6YlelA0tz/vJW3540kBMAmVmvzPfI1ac
 github.com/fnproject/fdk-go v0.0.6/go.mod h1:9m+nEyku9SqJAVJQsfZOZBQzFkCs+jvmbZJhvgDX4ts=
 github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/serverless.yml
+++ b/serverless.yml
@@ -63,7 +63,7 @@ functions:
   storeLgtmImage:
     handler: bin/storelgtmimage
     environment:
-      DB_READER_HOSTNAME: ${env:DB_READER_HOSTNAME}
+      DB_READER_HOSTNAME: ${env:DB_HOSTNAME}
       DB_USERNAME: ${env:DB_USERNAME}
       DB_PASSWORD: ${env:DB_PASSWORD}
       DB_NAME: ${env:DB_NAME}

--- a/serverless.yml
+++ b/serverless.yml
@@ -22,7 +22,6 @@ provider:
           Resource: "*"
   environment:
     DEPLOY_STAGE: ${env:DEPLOY_STAGE}
-    DESTINATION_BUCKET_NAME: ${env:DESTINATION_BUCKET_NAME}
     REGION: ${env:REGION}
 
 custom:
@@ -40,22 +39,44 @@ package:
 functions:
   generateLgtmImage:
     handler: bin/generatelgtmimage
+    environment:
+      DESTINATION_BUCKET_NAME: ${env:DESTINATION_BUCKET_NAME}
     events:
       - s3:
-          bucket: ${env:TRIGGER_BUCKET_NAME}
+          bucket: ${env:GENERATE_TRIGGER_BUCKET_NAME}
           event: s3:ObjectCreated:*
           rules:
             - suffix: .png
           existing: true
       - s3:
-          bucket: ${env:TRIGGER_BUCKET_NAME}
+          bucket: ${env:GENERATE_TRIGGER_BUCKET_NAME}
           event: s3:ObjectCreated:*
           rules:
             - suffix: .jpg
           existing: true
       - s3:
-          bucket: ${env:TRIGGER_BUCKET_NAME}
+          bucket: ${env:GENERATE_TRIGGER_BUCKET_NAME}
           event: s3:ObjectCreated:*
           rules:
             - suffix: .jpeg
+          existing: true
+  storeLgtmImage:
+    handler: bin/storelgtmimage
+    environment:
+      DB_READER_HOSTNAME: ${env:DB_READER_HOSTNAME}
+      DB_USERNAME: ${env:DB_USERNAME}
+      DB_PASSWORD: ${env:DB_PASSWORD}
+      DB_NAME: ${env:DB_NAME}
+    vpc:
+      securityGroupIds:
+        - ${env:SECURITY_GROUP_ID}
+      subnetIds:
+        - ${env:SUBNET_ID_1}
+        - ${env:SUBNET_ID_2}
+    events:
+      - s3:
+          bucket: ${env:STORE_TRIGGER_BUCKET_NAME}
+          event: s3:ObjectCreated:*
+          rules:
+            - suffix: .webp
           existing: true


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-lambda/issues/3

# Doneの定義
- LambdaからRDSに接続できること

# 変更点概要
RDS Proxyを使ってLambdaからRDSに接続できることを確認するためのLambda関数を作成。
Lambdaの処理自体は、別のPRで変更することを想定している。

Lambdaについて
- RDSに接続するためVPC内部に構築
- RDSはパブリックサブネットに構築しているため、Lambda自体もパブリックサブネットに構築
- サブネットとLambdaのセキュリティグループは事前にTerraformで構築したもの使用

## 補足
RDS Proxyの構築は https://github.com/nekochans/lgtm-cat-terraform/pull/37 にて対応中。