### PR TITLE
lgtm-cat-migration で定義した schema の変更に合わせて更新

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -8,4 +8,4 @@ CREATE TABLE `lgtm_images`
     PRIMARY KEY (`id`),
     UNIQUE KEY `uq_lgtm_images_01` (`filename`),
     KEY          `idx_lgtm_images_01` (`path`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin ROW_FORMAT=DYNAMIC;
+);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -8,4 +8,4 @@ CREATE TABLE `lgtm_images`
     PRIMARY KEY (`id`),
     UNIQUE KEY `uq_lgtm_images_01` (`filename`),
     KEY          `idx_lgtm_images_01` (`path`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin ROW_FORMAT=DYNAMIC;


### PR DESCRIPTION
# issueURL
なし

# 関連URL
https://github.com/nekochans/lgtm-cat-migration/pull/7

# Doneの定義
lgtm-cat-migration で定義している schema と同じ schema が定義されていること

# 変更点概要
MySQLを8.0にアップグレードする対応で、 lgtm-cat-migration で定義した schema を変更した。
上記の変更に合わせる形で、schema.sql を更新。
